### PR TITLE
Allow specifying drawing a specific card type

### DIFF
--- a/eldritch/events.py
+++ b/eldritch/events.py
@@ -567,15 +567,19 @@ class Draw(Event):
       self.drawn = []
       deck = getattr(state, self.deck)
       i = 0
+      decksize = len(deck)
       while len(self.drawn) < self.draw_count:
         i += 1
-        if not deck or i > 100:
+        if not deck :
           break
         top = deck.popleft()
         if self.target_type is None or isinstance(top, self.target_type):
           self.drawn.append(top)
         else:
           deck.append(top)
+
+        if i >= decksize:
+          break
       # TODO: is there a scenario when the player can go insane/unconscious before they
       # successfully pick a card?
 

--- a/eldritch/events.py
+++ b/eldritch/events.py
@@ -535,7 +535,7 @@ class ForceMovement(Event):
 
 class Draw(Event):
 
-  def __init__(self, character, deck, draw_count, prompt="Choose a card"):
+  def __init__(self, character, deck, draw_count, prompt="Choose a card", target_type=None):
     assert deck in {"common", "unique", "spells", "skills", "allies"}
     self.character = character
     self.deck = deck
@@ -545,6 +545,7 @@ class Draw(Event):
     self.drawn = None
     self.choice = None
     self.kept = None
+    self.target_type = target_type
 
   def resolve(self, state):
     if self.kept is not None:
@@ -565,10 +566,16 @@ class Draw(Event):
     if self.drawn is None:
       self.drawn = []
       deck = getattr(state, self.deck)
-      for _ in range(self.draw_count):
-        if not deck:
+      i = 0
+      while len(self.drawn) < self.draw_count:
+        i += 1
+        if not deck or i > 100:
           break
-        self.drawn.append(deck.popleft())
+        top = deck.popleft()
+        if self.target_type is None or isinstance(top, self.target_type):
+          self.drawn.append(top)
+        else:
+          deck.append(top)
       # TODO: is there a scenario when the player can go insane/unconscious before they
       # successfully pick a card?
 

--- a/eldritch/test_events.py
+++ b/eldritch/test_events.py
@@ -491,6 +491,18 @@ class DrawRandomTest(EventTest):
     self.assertEqual(self.char.possessions, [tommygun])
     self.assertEqual([item.name for item in self.state.common], ["Dynamite", "Food"])
 
+  def testDrawSpecificTypeNone(self):
+    draw = Draw(self.char, "common", 1, target_type=items.ResearchMaterials)
+    tommygun = items.TommyGun()
+    self.state.common.extend([items.Food(), tommygun, items.Dynamite(), ])
+    self.assertFalse(draw.is_resolved())
+    self.assertFalse(self.char.possessions)
+    self.state.event_stack.append(draw)
+    self.resolve_until_done()
+    self.assertEqual(self.char.possessions, [])
+    self.assertEqual([item.name for item in self.state.common], ["Food", "Tommy Gun", "Dynamite", ])
+
+
 
 class AttributePrerequisiteTest(EventTest):
 

--- a/eldritch/test_events.py
+++ b/eldritch/test_events.py
@@ -469,6 +469,28 @@ class DrawRandomTest(EventTest):
     self.assertEqual(self.char.possessions, [food])
     self.assertFalse(self.state.common)
 
+  def testDrawSpecificTypeTop(self):
+    draw = Draw(self.char, "common", 1, target_type=items.Weapon)
+    tommygun = items.TommyGun()
+    self.state.common.extend([tommygun, items.Food(), ])
+    self.assertFalse(draw.is_resolved())
+    self.assertFalse(self.char.possessions)
+    self.state.event_stack.append(draw)
+    self.resolve_until_done()
+    self.assertEqual(self.char.possessions, [tommygun])
+    self.assertEqual([item.name for item in self.state.common], ["Food"])
+
+  def testDrawSpecificTypeMiddle(self):
+    draw = Draw(self.char, "common", 1, target_type=items.Weapon)
+    tommygun = items.TommyGun()
+    self.state.common.extend([items.Food(), tommygun, items.Dynamite(), ])
+    self.assertFalse(draw.is_resolved())
+    self.assertFalse(self.char.possessions)
+    self.state.event_stack.append(draw)
+    self.resolve_until_done()
+    self.assertEqual(self.char.possessions, [tommygun])
+    self.assertEqual([item.name for item in self.state.common], ["Dynamite", "Food"])
+
 
 class AttributePrerequisiteTest(EventTest):
 


### PR DESCRIPTION
For instance, "Search the deck for a Weapon", or "Search the Deck for a
Tome" (though we don't yet have Tome as a type).

I think we should probably keep using python types instead of the
Item.item_type attribute to allow for inheritance, but I'm open to suggestions.