### PR TITLE
EventMonster to allow facing single-rounds of combat in Events

### DIFF
--- a/eldritch/events.py
+++ b/eldritch/events.py
@@ -3479,7 +3479,7 @@ class PassEvadeRound(Event):
 
 class CombatRound(Event):
 
-  def __init__(self, character, monster):
+  def __init__(self, character, monster, deactivate=False):
     super().__init__()
     self.character = character
     self.monster = monster
@@ -3492,6 +3492,7 @@ class CombatRound(Event):
     self.defeated = None
     self.damage: Optional[Event] = None
     self.pass_combat: Optional[Event] = None
+    self.deactivate = deactivate
     self.done = False
 
   def resolve(self, state):
@@ -3514,6 +3515,14 @@ class CombatRound(Event):
           self.character, "combat", self.monster.difficulty("combat", state, self.character), attrs)
     if not self.check.is_done():
       state.event_stack.append(self.check)
+      return
+
+    if self.deactivate and not isinstance(self.deactivate, Event):
+      self.deactivate = Sequence(
+          [DeactivateItems(self.character), DeactivateSpells(self.character)],
+          self.character
+      )
+      state.event_stack.append(self.deactivate)
       return
 
     if self.defeated is None:

--- a/eldritch/items/spells.py
+++ b/eldritch/items/spells.py
@@ -279,6 +279,8 @@ class RedSign(CombatSpell):
     if not isinstance(getattr(event, "monster", None), monsters.Monster):
       return None
     attributes = sorted(event.monster.attributes(state, owner) - self.INVALID_ATTRIBUTES)
+    if not attributes and event.monster.toughness(state, event.character) == 1:
+      return None
     choices = attributes + ["none", "Cancel"]
     spend = values.ExactSpendPrerequisite({"sanity": self.sanity_cost})
     spends = [spend] * (len(choices)-1) + [None]

--- a/eldritch/monsters.py
+++ b/eldritch/monsters.py
@@ -427,6 +427,29 @@ def Zombie():
   )
 
 
+class EventMonster(Monster):
+  """A pseudo-monster used for events like Bank3 and Hospital2"""
+
+  def __init__(self, name, rating, pass_event, fail_event, toughness=1, attributes=None):
+    super().__init__(
+        name, "normal", "moon", {"evade": 0} | rating,
+        {"combat": 0, }, toughness, attributes or set()
+    )
+    self.pass_event = pass_event
+    self.fail_event = fail_event
+
+  def get_trigger(self, event, state):
+    if isinstance(event, events.PassCombatRound):
+      return self.pass_event
+
+    if not isinstance(event, events.CombatRound) or not event.check.is_done():
+      return None
+
+    if (event.check.successes or 0) < self.toughness(state, event.character):
+      return events.Sequence([events.CancelEvent(event), self.fail_event], event.character)
+    return None
+
+
 MONSTERS = {
     x().name: x for x in [
         GiantInsect, LandSquid, Cultist, TentacleTree, DimensionalShambler, GiantWorm, ElderThing,

--- a/eldritch/monsters.py
+++ b/eldritch/monsters.py
@@ -444,7 +444,7 @@ class EventMonster(Monster):
 
     if ((not isinstance(event, events.CombatRound))
         or event.check is None
-        or not event.check.is_done()):
+            or not event.check.is_done()):
       return None
 
     if (event.check.successes or 0) < self.toughness(state, event.character):

--- a/eldritch/monsters.py
+++ b/eldritch/monsters.py
@@ -432,7 +432,7 @@ class EventMonster(Monster):
 
   def __init__(self, name, rating, pass_event, fail_event, toughness=1, attributes=None):
     super().__init__(
-        name, "normal", "moon", {"evade": 0} | rating,
+        name, "normal", "moon",  dict(evade=0, **rating),
         {"combat": 0, }, toughness, attributes or set()
     )
     self.pass_event = pass_event
@@ -442,11 +442,13 @@ class EventMonster(Monster):
     if isinstance(event, events.PassCombatRound):
       return self.pass_event
 
-    if not isinstance(event, events.CombatRound) or not event.check.is_done():
+    if ((not isinstance(event, events.CombatRound))
+        or event.check is None
+        or not event.check.is_done()):
       return None
 
     if (event.check.successes or 0) < self.toughness(state, event.character):
-      return events.Sequence([events.CancelEvent(event), self.fail_event], event.character)
+      return self.fail_event
     return None
 
 

--- a/eldritch/monsters.py
+++ b/eldritch/monsters.py
@@ -428,7 +428,7 @@ def Zombie():
 
 
 class EventMonster(Monster):
-  """A pseudo-monster used for events like Bank3 and Hospital2"""
+  """A pseudo-monster used for events like Bank3, Hospital2, and Graveyard3"""
 
   def __init__(self, name, rating, pass_event, fail_event, toughness=1, attributes=None):
     super().__init__(

--- a/eldritch/test_combat.py
+++ b/eldritch/test_combat.py
@@ -2650,7 +2650,7 @@ class CombatWithRedSignTest(EventTest):
 
   def testCastFutilely(self):
     giant_insect = monsters.GiantInsect()
-    choose_weapons = self.start(giant_insect)
+    self.start(giant_insect)
     self.assertEqual(giant_insect.toughness(self.state, self.char), 1)
 
     self.assertNotIn("Red Sign0", self.state.usables.get(0, {}))

--- a/eldritch/test_combat.py
+++ b/eldritch/test_combat.py
@@ -2648,25 +2648,12 @@ class CombatWithRedSignTest(EventTest):
     self.assertFalse(self.char.possessions[2].in_use)
     self.assertFalse(self.char.possessions[2].exhausted)
 
-  def testToughnessCannotBeLessThanOne(self):
+  def testCastFutilely(self):
     giant_insect = monsters.GiantInsect()
     choose_weapons = self.start(giant_insect)
     self.assertEqual(giant_insect.toughness(self.state, self.char), 1)
 
-    self.state.event_stack.append(self.state.usables[0]["Red Sign0"])
-    choose_ignore = self.resolve_to_choice(SpendChoice)
-    self.assertEqual(choose_ignore.choices, ["none", "Cancel"])
-    self.spend("sanity", 1, choose_ignore)
-    choose_ignore.resolve(self.state, "none")
-
-    with mock.patch.object(events.random, "randint", new=mock.MagicMock(return_value=5)):
-      choose_weapons = self.resolve_to_choice(CombatChoice)
-    self.assertEqual(giant_insect.toughness(self.state, self.char), 1)
-    self.choose_items(choose_weapons, [".38 Revolver0"])
-
-    with mock.patch.object(events.random, "randint", new=mock.MagicMock(return_value=5)) as rand:
-      self.resolve_until_done()
-      self.assertEqual(rand.call_count, 7)  # Fight (4) + insect 0 + revolver (3)
+    self.assertNotIn("Red Sign0", self.state.usables.get(0, {}))
 
   def testIgnoresMagicalResistance(self):
     witch = monsters.Witch()

--- a/eldritch/test_encounters.py
+++ b/eldritch/test_encounters.py
@@ -4719,6 +4719,8 @@ class GraveyardTest(EncounterTest):
     self.char.fight_will_slider = 2
     self.state.unique.append(items.HolyWater(0))
     self.state.event_stack.append(encounters.Graveyard3(self.char))
+    choice = self.resolve_to_choice(events.CombatChoice)
+    choice.resolve(self.state, "done")
     with mock.patch.object(events.random, "randint", new=mock.MagicMock(return_value=5)):
       self.resolve_until_done()
     self.assertEqual(self.char.clues, 1)
@@ -4730,6 +4732,8 @@ class GraveyardTest(EncounterTest):
     self.char.stamina = 4
     self.state.unique.append(items.HolyWater(0))
     self.state.event_stack.append(encounters.Graveyard3(self.char))
+    choice = self.resolve_to_choice(events.CombatChoice)
+    choice.resolve(self.state, "done")
     with mock.patch.object(events.random, "randint", new=mock.MagicMock(return_value=1)):
       self.resolve_until_done()
     self.assertEqual(self.char.stamina, 3)
@@ -4739,6 +4743,8 @@ class GraveyardTest(EncounterTest):
     self.char.stamina = 4
     self.state.unique.append(items.HolyWater(0))
     self.state.event_stack.append(encounters.Graveyard3(self.char))
+    choice = self.resolve_to_choice(events.CombatChoice)
+    choice.resolve(self.state, "done")
     with mock.patch.object(events.random, "randint", new=mock.MagicMock(return_value=2)):
       self.resolve_until_done()
     self.assertEqual(self.char.stamina, 2)
@@ -4748,6 +4754,8 @@ class GraveyardTest(EncounterTest):
     self.char.stamina = 4
     self.state.unique.append(items.HolyWater(0))
     self.state.event_stack.append(encounters.Graveyard3(self.char))
+    choice = self.resolve_to_choice(events.CombatChoice)
+    choice.resolve(self.state, "done")
     with mock.patch.object(events.random, "randint", new=mock.MagicMock(return_value=3)):
       self.resolve_until_done()
     self.assertEqual(self.char.stamina, 1)
@@ -4757,6 +4765,8 @@ class GraveyardTest(EncounterTest):
     self.char.stamina = 5
     self.state.unique.append(items.HolyWater(0))
     self.state.event_stack.append(encounters.Graveyard3(self.char))
+    choice = self.resolve_to_choice(events.CombatChoice)
+    choice.resolve(self.state, "done")
     with mock.patch.object(events.random, "randint", new=mock.MagicMock(return_value=4)):
       self.resolve_until_done()
     self.assertEqual(self.char.stamina, 1)
@@ -4766,6 +4776,8 @@ class GraveyardTest(EncounterTest):
     self.char.stamina = 4
     self.state.unique.append(items.HolyWater(0))
     self.state.event_stack.append(encounters.Graveyard3(self.char))
+    choice = self.resolve_to_choice(events.CombatChoice)
+    choice.resolve(self.state, "done")
     with mock.patch.object(events.random, "randint", new=mock.MagicMock(return_value=4)):
       choice = self.resolve_to_choice(ItemLossChoice)
     self.choose_items(choice, [])


### PR DESCRIPTION
This actually fixes a bug with the Graveyard3 encounter that weapons weren't usable, while simplifying the Bank and Hospital encounters. 