### PR TITLE
Silence some new pylint flags

### DIFF
--- a/eldritch/monsters.py
+++ b/eldritch/monsters.py
@@ -444,7 +444,7 @@ class EventMonster(Monster):
 
   def __init__(self, name, rating, pass_event, fail_event, toughness=1, attributes=None):
     super().__init__(
-        name, "normal", "moon",  dict(evade=0, **rating),
+        name, "normal", "moon",  {"evade": 0, **rating},
         {"combat": 0, }, toughness, attributes or set()
     )
     self.pass_event = pass_event

--- a/islanders/islanders.py
+++ b/islanders/islanders.py
@@ -701,11 +701,11 @@ class IslandersState:
     for idx, corner_list in self.foreign_landings.items():
       ret["landings"].extend([{"location": corner, "player": idx} for corner in corner_list])
 
-    is_over = (self.game_phase == "victory")
+    is_over = self.game_phase == "victory"
 
     ret["player_data"] = [player.json_for_player(is_over) for player in self.player_data]
     for idx in range(len(self.player_data)):
-      ret["player_data"][idx]["points"] = self.player_points(idx, visible=(not is_over))
+      ret["player_data"][idx]["points"] = self.player_points(idx, visible=not is_over)
     return ret
 
   def player_points(self, idx, visible):


### PR DESCRIPTION
https://pylint.pycqa.org/en/latest/whatsnew/2/2.16/index.html

* Extended use-dict-literal to also warn about call to dict() when passing keyword arguments
* Flag superfluous-parens if parentheses are used during string concatenation.